### PR TITLE
Fix app title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Smart Speakers Commands Speaker(SCSS)</title>
+    <title>Smart Speaker's Commands Speaker(SCSS)</title>
   </head>
   <body>
     <noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ class App extends Component {
           </div>
         <div className="jumbotron">
           <header className="text-center">
-            <h2>Smart Speaker Commands Speaker （SCSS）</h2>
+            <h2>Smart Speaker's Commands Speaker （SCSS）</h2>
             <p>スマートスピーカーのコマンドを日本語で発音して代行してくれるサイトです。コマンドをクリックすると発音されます。<br/>
               コマンドの追加は<a href="https://github.com/eishis/smart-speakers-commands-speaker" target="_blank" rel="noopener noreferrer">こちらから</a>お願いします。
             </p>


### PR DESCRIPTION
Fix some of title descriptions differing from `Smart Speaker's Commands Speaker` .